### PR TITLE
Allow custom implementation of MapperFacade

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/BoundMapperFacade.java
+++ b/core/src/main/java/ma/glasnost/orika/BoundMapperFacade.java
@@ -73,7 +73,7 @@ public interface BoundMapperFacade<A, B> extends MappedTypePair<A, B> {
      * @param source
      * @param destination
      */
-    void map(A instanceA, B instanceB);
+    B map(A instanceA, B instanceB);
     
     /**
      * 
@@ -84,7 +84,7 @@ public interface BoundMapperFacade<A, B> extends MappedTypePair<A, B> {
      * @param context
      * @param destination
      */
-    void map(A instanceA, B instanceB, MappingContext context);
+    B map(A instanceA, B instanceB, MappingContext context);
     
     /**
      * Maps properties (in place) from the instance of 'B' to the provided
@@ -93,7 +93,7 @@ public interface BoundMapperFacade<A, B> extends MappedTypePair<A, B> {
      * @param destination
      * @param source
      */
-    void mapReverse(B instanceB, A instanceA);
+    A mapReverse(B instanceB, A instanceA);
     
     /**
      * Maps properties (in place) from the instance of 'B' to the provided
@@ -103,7 +103,7 @@ public interface BoundMapperFacade<A, B> extends MappedTypePair<A, B> {
      * @param context
      * @param source
      */
-    void mapReverse(B instanceB, A instanceA, MappingContext context);
+    A mapReverse(B instanceB, A instanceA, MappingContext context);
     
     
     /**

--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultBoundMapperFacade.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultBoundMapperFacade.java
@@ -105,19 +105,19 @@ class DefaultBoundMapperFacade<A, B> implements BoundMapperFacade<A, B> {
         }
     }
     
-    public void map(A instanceA, B instanceB) {
+    public B map(A instanceA, B instanceB) {
         MappingContext context = contextFactory.getContext();
         try {
-            map(instanceA, instanceB, context);
+           return map(instanceA, instanceB, context);
         } finally {
             contextFactory.release(context);
         }
     }
     
-    public void mapReverse(B instanceB, A instanceA) {
+    public A mapReverse(B instanceB, A instanceA) {
         MappingContext context = contextFactory.getContext();
         try {
-            mapReverse(instanceB, instanceA, context);
+           return mapReverse(instanceB, instanceA, context);
         } finally {
             contextFactory.release(context);
         }
@@ -159,10 +159,12 @@ class DefaultBoundMapperFacade<A, B> implements BoundMapperFacade<A, B> {
      * @see ma.glasnost.orika.DedicatedMapperFacade#mapAtoB(java.lang.Object,
      * java.lang.Object, ma.glasnost.orika.MappingContext)
      */
-    public void map(A instanceA, B instanceB, MappingContext context) {
+    @SuppressWarnings("unchecked")
+    public B map(A instanceA, B instanceB, MappingContext context) {
         if (context.getMappedObject(instanceA, bType) == null && instanceA != null) {
-            aToBInPlace.getStrategy(instanceA, context).map(instanceA, instanceB, context);
+            return (B) aToBInPlace.getStrategy(instanceA, context).map(instanceA, instanceB, context);
         }
+        return null;
     }
     
     /*
@@ -171,10 +173,12 @@ class DefaultBoundMapperFacade<A, B> implements BoundMapperFacade<A, B> {
      * @see ma.glasnost.orika.DedicatedMapperFacade#mapBtoA(java.lang.Object,
      * java.lang.Object, ma.glasnost.orika.MappingContext)
      */
-    public void mapReverse(B instanceB, A instanceA, MappingContext context) {
+    @SuppressWarnings("unchecked")
+    public A mapReverse(B instanceB, A instanceA, MappingContext context) {
         if (context.getMappedObject(instanceB, aType) == null && instanceB != null) {
-            bToAInPlace.getStrategy(instanceB, context).map(instanceB, instanceA, context);
+            return (A) bToAInPlace.getStrategy(instanceB, context).map(instanceB, instanceA, context);
         }
+        return null;
     }
     
     public String toString() {

--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultBoundMapperFacade.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultBoundMapperFacade.java
@@ -161,10 +161,11 @@ class DefaultBoundMapperFacade<A, B> implements BoundMapperFacade<A, B> {
      */
     @SuppressWarnings("unchecked")
     public B map(A instanceA, B instanceB, MappingContext context) {
-        if (context.getMappedObject(instanceA, bType) == null && instanceA != null) {
-            return (B) aToBInPlace.getStrategy(instanceA, context).map(instanceA, instanceB, context);
+        B result = (B) context.getMappedObject(instanceA, bType);
+		if (result == null && instanceA != null) {
+            result = (B) aToBInPlace.getStrategy(instanceA, context).map(instanceA, instanceB, context);
         }
-        return null;
+        return result;
     }
     
     /*
@@ -175,10 +176,11 @@ class DefaultBoundMapperFacade<A, B> implements BoundMapperFacade<A, B> {
      */
     @SuppressWarnings("unchecked")
     public A mapReverse(B instanceB, A instanceA, MappingContext context) {
-        if (context.getMappedObject(instanceB, aType) == null && instanceB != null) {
-            return (A) bToAInPlace.getStrategy(instanceB, context).map(instanceB, instanceA, context);
+    	A result = (A) context.getMappedObject(instanceB, aType);
+		if (result == null && instanceB != null) {
+            result = (A) bToAInPlace.getStrategy(instanceB, context).map(instanceB, instanceA, context);
         }
-        return null;
+        return result;
     }
     
     public String toString() {

--- a/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/DefaultMapperFactory.java
@@ -84,7 +84,7 @@ public class DefaultMapperFactory implements MapperFactory {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMapperFactory.class);
     
-    private final MapperFacadeImpl mapperFacade;
+    private final MapperFacade mapperFacade;
     private final MapperGenerator mapperGenerator;
     private final ObjectFactoryGenerator objectFactoryGenerator;
     
@@ -128,7 +128,7 @@ public class DefaultMapperFactory implements MapperFactory {
         this.defaultFieldMappers = new CopyOnWriteArrayList<DefaultFieldMapper>();
         this.unenhanceStrategy = buildUnenhanceStrategy(builder.unenhanceStrategy, builder.superTypeStrategy);
         this.contextFactory = new MappingContext.Factory();
-        this.mapperFacade = new MapperFacadeImpl(this, contextFactory, unenhanceStrategy);
+        this.mapperFacade = buildMapperFacade(contextFactory, unenhanceStrategy);
         this.concreteTypeRegistry = new ConcurrentHashMap<java.lang.reflect.Type, Type<?>>();
         
         if (builder.classMaps != null) {
@@ -175,7 +175,7 @@ public class DefaultMapperFactory implements MapperFactory {
         this.registerConcreteType(Map.class, LinkedHashMap.class);
         this.registerConcreteType(Map.Entry.class, MapEntry.class);
     }
-    
+
     /**
      * MapperFactoryBuilder provides an extensible Builder definition usable for
      * providing your own Builder class for subclasses of DefaultMapperFactory.<br>
@@ -556,6 +556,20 @@ public class DefaultMapperFactory implements MapperFactory {
         return unenhancer;
         
     }
+    
+    /**
+	 * Builds the MapperFacade for this factory. Subclasses can override this
+	 * method to build a custom MapperFacade. Please note that this method is
+	 * called from the constructor and as such properties of the factory may not
+	 * yet be initialized.
+	 * 
+	 * @param contextFactory
+	 * @param unenhanceStrategy
+	 * @return the MapperFacade to use
+	 */
+	protected MapperFacade buildMapperFacade(MappingContextFactory contextFactory, UnenhanceStrategy unenhanceStrategy) {
+		return new MapperFacadeImpl(this, contextFactory, unenhanceStrategy);
+	}
     
     /*
      * (non-Javadoc)

--- a/core/src/main/java/ma/glasnost/orika/impl/NonCyclicBoundMapperFacade.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/NonCyclicBoundMapperFacade.java
@@ -44,11 +44,11 @@ public class NonCyclicBoundMapperFacade<A, B> extends DefaultBoundMapperFacade<A
         return super.mapReverse(source, nonCyclicContext);
     }
     
-    public void map(A source, B destination) {
-        super.map(source, destination, nonCyclicContext);
+    public B map(A source, B destination) {
+        return super.map(source, destination, nonCyclicContext);
     }
     
-    public void mapReverse(B destination, A source) {
-        super.mapReverse(destination, source, nonCyclicContext);
+    public A mapReverse(B destination, A source) {
+        return super.mapReverse(destination, source, nonCyclicContext);
     }
 }

--- a/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ObjectToObject.java
+++ b/core/src/main/java/ma/glasnost/orika/impl/generator/specification/ObjectToObject.java
@@ -21,7 +21,7 @@ public class ObjectToObject extends AbstractSpecification {
     public String generateMappingCode(VariableRef source, VariableRef destination, Property inverseProperty, SourceCodeContext code) {
         
         String mapNewObject = destination.assign(format("(%s)%s(%s, mappingContext)", destination.typeName(), code.usedMapperFacadeCall(source, destination), source));
-        String mapExistingObject = format("%s(%s, %s, mappingContext)", code.usedMapperFacadeCall(source, destination), source, destination);
+        String mapExistingObject = destination.assign(format("(%s)%s(%s, %s, mappingContext)", destination.typeName(), code.usedMapperFacadeCall(source, destination), source, destination));
         String mapStmt = format(" %s { %s; } else { %s; }", destination.ifNull(), mapNewObject, mapExistingObject);
         
         String ipStmt = "";

--- a/core/src/test/java/ma/glasnost/orika/test/extensibility/PooledInstancesTestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/extensibility/PooledInstancesTestCase.java
@@ -1,0 +1,212 @@
+package ma.glasnost.orika.test.extensibility;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import ma.glasnost.orika.BoundMapperFacade;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.metadata.Type;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PooledInstancesTestCase {
+
+	public static class MyMapperFactory extends DefaultMapperFactory {
+		public static class Builder extends
+				MapperFactoryBuilder<MyMapperFactory, Builder> {
+
+			protected Builder self() {
+				return this;
+			}
+
+			public MyMapperFactory build() {
+				return new MyMapperFactory(this);
+			}
+		}
+
+		private static class PoolingBoundMapperFacade<A, B> implements
+				BoundMapperFacade<A, B> {
+			private BoundMapperFacade<A, B> wrapped;
+			private Map<String, Pooled> pool;
+
+			public PoolingBoundMapperFacade(BoundMapperFacade<A, B> wrapped,
+					Map<String, Pooled> pool) {
+				this.wrapped = wrapped;
+				this.pool = pool;
+			}
+
+			@SuppressWarnings("unchecked")
+			public B map(A instanceA) {
+				return (B) pool.get(((SourcePoolView) instanceA).getName());
+			}
+
+			public Type<A> getAType() {
+				return wrapped.getAType();
+			}
+
+			public Type<B> getBType() {
+				return wrapped.getBType();
+			}
+
+			@SuppressWarnings("unchecked")
+			public B map(A instanceA, MappingContext context) {
+				return (B) pool.get(((SourcePoolView) instanceA).getName());
+			}
+
+			public A mapReverse(B instanceB) {
+				return wrapped.mapReverse(instanceB);
+			}
+
+			public A mapReverse(B instanceB, MappingContext context) {
+				return wrapped.mapReverse(instanceB, context);
+			}
+
+			public void map(A instanceA, B instanceB) {
+				pool.get(((SourcePoolView) instanceA).getName());
+			}
+
+			public void map(A instanceA, B instanceB, MappingContext context) {
+				pool.get(((SourcePoolView) instanceA).getName());
+			}
+
+			public void mapReverse(B instanceB, A instanceA) {
+				wrapped.mapReverse(instanceB, instanceA);
+			}
+
+			public void mapReverse(B instanceB, A instanceA,
+					MappingContext context) {
+				wrapped.mapReverse(instanceB, instanceA, context);
+			}
+
+			public B newObject(A source, MappingContext context) {
+				return wrapped.newObject(source, context);
+			}
+
+			public A newObjectReverse(B source, MappingContext context) {
+				return wrapped.newObjectReverse(source, context);
+			}
+		}
+
+		/**
+		 * Since DefaultMapperFactory uses (some form of) the Builder pattern,
+		 * we need to provide a constructor which can accept an appropriate
+		 * builder and pass it to the super constructor.
+		 * 
+		 * @param builder
+		 */
+		protected MyMapperFactory(Builder builder) {
+			super(builder);
+			pool.put("A", new Pooled("A"));
+			pool.put("B", new Pooled("B"));
+			pool.put("C", new Pooled("C"));
+		}
+
+		private Map<String, Pooled> pool = new HashMap<String, Pooled>();
+
+		public Map<String, Pooled> getPool() {
+			return pool;
+		}
+
+		public <S, D> BoundMapperFacade<S, D> getMapperFacade(
+				Type<S> sourceType, Type<D> destinationType,
+				boolean containsCycles) {
+			BoundMapperFacade<S, D> ret = super.getMapperFacade(sourceType,
+					destinationType, containsCycles);
+			if (sourceType.getRawType().equals(SourcePoolView.class)
+					&& destinationType.getRawType().equals(Pooled.class)) {
+				ret = new PoolingBoundMapperFacade<S, D>(ret, pool);
+			}
+			return ret;
+		}
+	}
+
+	@Test
+	public void testExtendedMapper() {
+		MyMapperFactory factory = new MyMapperFactory.Builder().build();
+		factory.registerClassMap(factory
+				.classMap(SourcePoolView.class, Pooled.class).byDefault()
+				.toClassMap());
+		factory.registerClassMap(factory
+				.classMap(SourceObject.class, DestObject.class).byDefault()
+				.toClassMap());
+
+		SourceObject source1 = new SourceObject();
+		source1.setPooled(new SourcePoolView("A"));
+		DestObject dest1 = factory.getMapperFacade().map(source1,
+				DestObject.class);
+
+		SourceObject source2 = new SourceObject();
+		source2.setPooled(new SourcePoolView("A"));
+		DestObject dest2 = factory.getMapperFacade().map(source2,
+				DestObject.class);
+		Assert.assertEquals(dest2.getPooled(), dest1.getPooled());
+
+		SourceObject source3 = new SourceObject();
+		source3.setPooled(new SourcePoolView("A"));
+		DestObject dest3 = new DestObject();
+		dest3.setPooled(factory.getPool().get("C"));
+		factory.getMapperFacade().map(source3, dest3);
+		Assert.assertEquals(dest3.getPooled(), dest1.getPooled());
+	}
+
+	public static class SourcePoolView {
+		private String name;
+
+		public SourcePoolView(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	public static class SourceObject {
+		private SourcePoolView pooled;
+
+		public SourcePoolView getPooled() {
+			return pooled;
+		}
+
+		public void setPooled(SourcePoolView pooled) {
+			this.pooled = pooled;
+		}
+	}
+
+	public static class Pooled {
+		private String name;
+
+		public Pooled() {
+		}
+
+		public Pooled(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	public static class DestObject {
+		private Pooled pooled;
+
+		public Pooled getPooled() {
+			return pooled;
+		}
+
+		public void setPooled(Pooled pooled) {
+			this.pooled = pooled;
+		}
+	}
+}

--- a/core/src/test/java/ma/glasnost/orika/test/extensibility/PooledInstancesTestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/extensibility/PooledInstancesTestCase.java
@@ -63,21 +63,22 @@ public class PooledInstancesTestCase {
 				return wrapped.mapReverse(instanceB, context);
 			}
 
-			public void map(A instanceA, B instanceB) {
-				pool.get(((SourcePoolView) instanceA).getName());
+			@SuppressWarnings("unchecked")
+			public B map(A instanceA, B instanceB) {
+				return (B) pool.get(((SourcePoolView) instanceA).getName());
 			}
 
-			public void map(A instanceA, B instanceB, MappingContext context) {
-				pool.get(((SourcePoolView) instanceA).getName());
+			@SuppressWarnings("unchecked")
+			public B map(A instanceA, B instanceB, MappingContext context) {
+				return (B) pool.get(((SourcePoolView) instanceA).getName());
 			}
 
-			public void mapReverse(B instanceB, A instanceA) {
-				wrapped.mapReverse(instanceB, instanceA);
+			public A mapReverse(B instanceB, A instanceA) {
+				return wrapped.mapReverse(instanceB, instanceA);
 			}
 
-			public void mapReverse(B instanceB, A instanceA,
-					MappingContext context) {
-				wrapped.mapReverse(instanceB, instanceA, context);
+			public A mapReverse(B instanceB, A instanceA, MappingContext context) {
+				return wrapped.mapReverse(instanceB, instanceA, context);
 			}
 
 			public B newObject(A source, MappingContext context) {


### PR DESCRIPTION
DefaultMapperFactory always creates a MapperFacadeImpl. It is possible to wrap this MapperFacade in a subclass by overriding getMapperFacade, but many method calls to MapperFacade are made from inside MapperFacadeImpl, making it impossible to intercept these method calls. With a custom MapperFacade (for example a subclass of MapperFacadeImpl), it is possible to intercept all calls, for example to wrap MappingStrategies.

This pull request contains a small patch to DefaultMapperFactory which makes it possible to build a custom MapperFacade. A minor issue is that the method is called from the constructor, when the instance variables of the factory are not yet initialized. IMHO it should be better to build these components in the builder, together with other components of the factory, but that would be a much bigger patch.
